### PR TITLE
Move the settings around to more appropriate places

### DIFF
--- a/ui/components/header.tsx
+++ b/ui/components/header.tsx
@@ -19,15 +19,11 @@
  */
 
 import {
-  ArrowUpOutlined,
-  CalendarOutlined,
   FileOutlined,
-  LineChartOutlined,
   LinkOutlined,
   LogoutOutlined,
-  MoreOutlined,
   PlusOutlined,
-  SettingOutlined,
+  SmileOutlined,
   UserOutlined,
 } from "@ant-design/icons";
 import {
@@ -46,9 +42,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { budgetSlice, headerSlice, navigate, store, View } from "../store";
 import { NumberToMonth } from "../utils";
-import { ShareBudgetModal } from "./share_budget_modal";
 import { LinkBudgetModal } from "./link_budget_modal";
-import { RolloverModal } from "./rollover_modal";
 import { NicknameModal } from "./nickname_modal";
 
 export interface HeaderBudgetDetails {
@@ -94,14 +88,6 @@ class Header extends React.Component<HeaderProps, HeaderState> {
         gap="small"
       >
         {this.render_budget_selector()}
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          size="large"
-          onClick={() => {
-            store.dispatch(navigate(View.CategoryEdit));
-          }}
-        ></Button>
         {this.render_more_menu()}
       </Flex>
     );
@@ -172,11 +158,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
           }))}
           defaultValue={defaultValue}
           onChange={onSelectionChanged}
-          onDropdownVisibleChange={(visible) => {
+          onOpenChange={(visible) => {
             this.setState({ is_budget_selector_visible: visible });
           }}
           open={this.state.is_budget_selector_visible}
-          dropdownRender={(menu) => (
+          popupRender={(menu) => (
             <>
               {menu}
               <Divider style={{ margin: "8px 0" }} />
@@ -222,92 +208,29 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   render_more_menu() {
-    const current_budget =
-      this.props.budget_list[this.props.selected_budget_index ?? 0];
-    let enable_proceed_next_month = false;
-    if (current_budget) {
-      const now = new Date(Date.now());
-      enable_proceed_next_month =
-        current_budget.period.month != now.getMonth() + 1;
-      enable_proceed_next_month =
-        enable_proceed_next_month ||
-        current_budget.period.year != now.getFullYear();
-    }
+   
     const items: MenuProps["items"] = [
-      {
-        label: "Proceed Next Month",
-        icon: <ArrowUpOutlined />,
-        key: "1",
-        disabled: !enable_proceed_next_month,
-        onClick: () => {
-          this.setState({ open_model: 'rollover' });
-        },
-      },
-      {
-        label: "Share Budget",
-        key: "2",
-        icon: <LinkOutlined />,
-        onClick: () => {
-          this.setState({ open_model: 'share' });
-        },
-        disabled: false,
-      },
       {
         label: "Edit Nickname",
         key: "3",
-        icon: <UserOutlined />,
         onClick: () => {
           this.setState({ open_model: 'edit_nickname' });
         },
         disabled: false,
       },
       {
-        label: "History",
-        key: "4",
-        icon: <CalendarOutlined />,
-        onClick: () => {},
-        disabled: true,
-      },
-      {
-        label: "Trends",
-        key: "5",
-        icon: <LineChartOutlined />,
-        onClick: () => {},
-        disabled: true,
-      },
-      {
         label: "Sign Out",
         key: "6",
-        icon: <LogoutOutlined />,
         onClick: () => {
           window.location.href = "/logout";
         },
       },
     ];
-    let defaultValue: number = this.props.selected_budget_index ?? 0;
-    let selected_budget = this.props.budget_list[defaultValue];
     return (
       <>
-        <Dropdown menu={{ items }} arrow>
-          <Button type="text" icon={<MoreOutlined />} size="large"></Button>
+        <Dropdown menu={{ items }} >
+          <Button type="default" icon={<UserOutlined />} shape="circle" size="large"></Button>
         </Dropdown>
-        <ShareBudgetModal
-          isOpen={this.state.open_model === 'share'}
-          budget_id={selected_budget?.id}
-          onDone={() => {
-            this.setState({ open_model: 'none' });
-          }}
-        />
-        <RolloverModal
-          isOpen={this.state.open_model === 'rollover'}
-          budget_id={selected_budget?.id}
-          onDone={() => {
-            this.setState({ open_model: 'none' });
-          }}
-          onClose={() => {
-            this.setState({ open_model: 'none' });
-          }}
-        />
         <NicknameModal
           isOpen={this.state.open_model === 'edit_nickname'}
           onDone={() => {

--- a/ui/pages/overview.tsx
+++ b/ui/pages/overview.tsx
@@ -23,17 +23,28 @@ import {
   Button,
   Card,
   Divider,
+  Dropdown,
   Empty,
   Flex,
   Input,
+  MenuProps,
   Progress,
   Spin,
   Statistic,
 } from "antd";
 import {
+  ArrowUpOutlined,
+  CalendarOutlined,
   CheckCircleOutlined,
+  DownCircleOutlined,
+  DownOutlined,
+  EditOutlined,
+  LineChartOutlined,
+  LinkOutlined,
   LoadingOutlined,
+  LogoutOutlined,
   PlusCircleFilled,
+  PlusOutlined,
   WalletOutlined,
 } from "@ant-design/icons";
 import {
@@ -66,6 +77,8 @@ import { connect } from "react-redux";
 import { AddExpenseModal } from "../components/add_expense_modal";
 import SingleCategory from "../components/single_category";
 import EditCategory, { EditCategoryState } from "../components/edit_category";
+import { ShareBudgetModal } from "../components/share_budget_modal";
+import { RolloverModal } from "../components/rollover_modal";
 
 const { Text } = Typography;
 
@@ -88,6 +101,7 @@ interface IState {
   upcoming_expense: { name: string; amount: number } | null;
   add_expense_mode_context: AddExpenseContext | null;
   previous_budget_index: number | null;
+  open_model: 'share' | 'rollover' | 'link' | 'edit_nickname' | 'none';
 }
 
 class OverviewPage extends React.Component<OverviewProps, IState> {
@@ -152,18 +166,68 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
     );
   }
 
-  render_add_expense_button() {
+  render_action_button() {
     if (this.props.selected_budget_index == null) return null;
     const budget = this.props.budget_list[this.props.selected_budget_index!];
     if (budget.categoryList.length === 0) return null;
     const first_category_id = budget.categoryList[0].id;
 
+    let enable_proceed_next_month = false;
+    const now = new Date(Date.now());
+    enable_proceed_next_month = budget.period.month != now.getMonth() + 1;
+    enable_proceed_next_month =  enable_proceed_next_month ||
+      budget.period.year != now.getFullYear();
+
+    const items: MenuProps["items"] = [
+      {
+        label: "Proceed Next Month",
+        icon: <ArrowUpOutlined />,
+        key: "1",
+        disabled: !enable_proceed_next_month,
+        onClick: () => {
+          this.setState({ open_model: 'rollover' });
+        },
+      },
+      {
+        label: "Edit Categories",
+        key: "3",
+        icon: <EditOutlined />,
+        onClick: () => {
+          store.dispatch(navigate(View.CategoryEdit));
+        }
+      },
+      {
+        label: "History",
+        key: "4",
+        icon: <CalendarOutlined />,
+        onClick: () => {},
+        disabled: true,
+      },
+      {
+        label: "Trends",
+        key: "5",
+        icon: <LineChartOutlined />,
+        onClick: () => {},
+        disabled: true,
+      },
+      {
+        label: "Share Budget",
+        key: "2",
+        icon: <LinkOutlined />,
+        onClick: () => {
+          this.setState({ open_model: 'share' });
+        },
+        disabled: false,
+      },
+    ];
+
     return (
       <div style={{ margin: 10 }}>
-        <Button
+        <Dropdown.Button
           type="default"
-          icon={<PlusCircleFilled />}
           size="large"
+          icon={<DownOutlined />}
+          menu={{items: items}}
           onClick={() => {
             this.setState({
               add_expense_mode_context: {
@@ -175,9 +239,28 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
               },
             });
           }}
-        >
+        ><PlusOutlined />
           Add Expense
-        </Button>
+        </Dropdown.Button>
+         <ShareBudgetModal
+                  isOpen={this.state.open_model === 'share'}
+                  budget_id={budget.id}
+                  onDone={() => {
+                    this.setState({ open_model: 'none' });
+                  }}
+                />
+        <RolloverModal
+          isOpen={this.state.open_model === 'rollover'}
+          budget_id={budget.id}
+          onDone={() => {
+            this.setState({ open_model: 'none' });
+          }}
+          onClose={() => {
+            this.setState({ open_model: 'none' });
+          }}
+        />
+        {this.render_add_expense_modal()}
+        
       </div>
     );
   }
@@ -191,7 +274,7 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
         gap={20}
       >
         {this.render_available_budget()}
-        {this.render_add_expense_button()}
+        {this.render_action_button()}
       </Flex>
     );
   }
@@ -422,7 +505,6 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
       >
         {this.header()}
         {this.render_categories()}
-        {this.render_add_expense_modal()}
       </Flex>
     );
   }
@@ -456,6 +538,7 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
       upcoming_expense: null,
       add_expense_mode_context: null,
       previous_budget_index: null,
+      open_model: 'none',
     };
   }
 


### PR DESCRIPTION
Move edit categories, and other budget specific menu items from the header to overview section. Now the UI becomes 

Overview (eveything budget related starts here)
| -> Edit categories
| -> Roll over
| -> Stats / trends

And header only container - 
* Budget context
* User context
* Potential user level settings