### PR TITLE
Fix budget linking flow and success message

### DIFF
--- a/ui/components/header.tsx
+++ b/ui/components/header.tsx
@@ -203,7 +203,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
               if (data.length) {
                 store.dispatch(budgetSlice.actions.set({
                   budget_list: data,
-                  selected_budget_index: data.length - 1,
+                  selected_budget_index: data.length - 1, // newly added budget is appended last
                 }));
               }
             });

--- a/ui/components/header.tsx
+++ b/ui/components/header.tsx
@@ -41,6 +41,7 @@ import {
 import React from "react";
 import { connect } from "react-redux";
 import { budgetSlice, headerSlice, navigate, store, View } from "../store";
+import { getDataService } from "../services/data_service";
 import { NumberToMonth } from "../utils";
 import { LinkBudgetModal } from "./link_budget_modal";
 import { NicknameModal } from "./nickname_modal";
@@ -198,6 +199,14 @@ class Header extends React.Component<HeaderProps, HeaderState> {
           isOpen={this.state.open_model === 'link'}
           onDone={() => {
             store.dispatch(navigate(View.Overview));
+            getDataService().getBudget().then((data) => {
+              if (data.length) {
+                store.dispatch(budgetSlice.actions.set({
+                  budget_list: data,
+                  selected_budget_index: data.length - 1,
+                }));
+              }
+            });
           }}
           onClose={() => {
             this.setState({ open_model: 'none' });

--- a/ui/components/link_budget_modal.tsx
+++ b/ui/components/link_budget_modal.tsx
@@ -45,7 +45,7 @@ export function LinkBudgetModal(props: {
     LinkBudget(code)
       .then(() => {
         props.onDone();
-        messageApi.error("Succesfully linked the budget.", 5);
+        messageApi.success("Successfully linked the budget.", 5);
       })
       .catch(() => {
         messageApi.error("Failed to link budget.", 5);


### PR DESCRIPTION
## Summary
This PR fixes the budget linking workflow by ensuring the budget list is refreshed after successfully linking a budget, and corrects the success message notification.

## Key Changes
- **Refresh budget list after linking**: Added a call to `getDataService().getBudget()` in the `LinkBudgetModal.onDone()` callback to fetch the updated budget list and automatically select the newly linked budget
- **Fix success message**: Changed the success notification from `messageApi.error()` to `messageApi.success()` and corrected the typo "Succesfully" to "Successfully"

## Implementation Details
- After a budget is successfully linked, the component now dispatches a Redux action to update the `budget_list` and set the `selected_budget_index` to the last item (the newly added budget)
- The budget refresh is conditional on the returned data having at least one item
- The user is navigated to the Overview view and the newly linked budget is automatically selected for immediate use

https://claude.ai/code/session_01XY4coqRCdoMiAfEUS2DrFA