### PR TITLE
Add expense editing functionality to ViewExpensePage

### DIFF
--- a/api/budget_controller.cs
+++ b/api/budget_controller.cs
@@ -101,6 +101,12 @@ public class BudgetController : ControllerBase
         return Ok(await _userDataService.AddExpenseToBudget(budget_id, expense));
     }
 
+    [HttpPut("{budget_id}/expense")]
+    public async Task<IActionResult> EditExpenseInput(string budget_id, Expense expense)
+    {
+        return Ok(await _userDataService.UpdateExpenseToBudget(budget_id, expense));
+    }
+
     [HttpDelete("{budget_id}/category/{category_id}/expense/{expense_id}")]
     public async Task<IActionResult> DeleteExpense(string budget_id, int category_id, int expense_id)
     {

--- a/api/services/db_service.cs
+++ b/api/services/db_service.cs
@@ -158,7 +158,7 @@ public class DbService
         return await UpdateUserNickName(budget);
     }
 
-    public async Task UpdateExpenseAsync(string budget_id, Expense expense)
+    public async Task<Budget> UpdateExpenseAsync(string budget_id, Expense expense)
     {
         Budget budget = await GetBudgetAsync(budget_id);
         expense.Timestamp = DateTime.UtcNow.Ticks;
@@ -166,6 +166,7 @@ public class DbService
         category.ExpenseList[category.ExpenseList.FindIndex(e => e.Id == expense.Id)] = expense;
         category.LastUpdated = DateTime.UtcNow.Ticks;
         await UpdateBudgetAsync(budget);
+        return await UpdateUserNickName(budget);
     }
 
     public async Task DeleteExpense(string budget_id, Expense expense)

--- a/api/services/db_service.cs
+++ b/api/services/db_service.cs
@@ -163,7 +163,9 @@ public class DbService
         Budget budget = await GetBudgetAsync(budget_id);
         expense.Timestamp = DateTime.UtcNow.Ticks;
         Category category = budget.categoryList?.Find(c => c.Id == expense.CategoryId) ?? throw new Exception("Category not found");
-        category.ExpenseList[category.ExpenseList.FindIndex(e => e.Id == expense.Id)] = expense;
+        int idx = category.ExpenseList.FindIndex(e => e.Id == expense.Id);
+        expense.AddedBy = category.ExpenseList[idx].AddedBy;
+        category.ExpenseList[idx] = expense;
         category.LastUpdated = DateTime.UtcNow.Ticks;
         await UpdateBudgetAsync(budget);
         return await UpdateUserNickName(budget);

--- a/api/services/user_data_service.cs
+++ b/api/services/user_data_service.cs
@@ -76,8 +76,7 @@ public class UserDataService
 
     public async Task<Budget> UpdateExpenseToBudget(string budget_id, Expense expense)
     {
-        await _dbService.UpdateExpenseAsync(budget_id, expense);
-        return await _dbService.GetBudgetAsync(budget_id);
+        return await _dbService.UpdateExpenseAsync(budget_id, expense);
     }
 
     public async Task<Budget> AddCategoryToBudget(string budget_id, List<Category> categoryList)

--- a/api/services/user_data_service.cs
+++ b/api/services/user_data_service.cs
@@ -74,6 +74,12 @@ public class UserDataService
         return await _dbService.AddExpenseAsync(budget_id, expense);
     }
 
+    public async Task<Budget> UpdateExpenseToBudget(string budget_id, Expense expense)
+    {
+        await _dbService.UpdateExpenseAsync(budget_id, expense);
+        return await _dbService.GetBudgetAsync(budget_id);
+    }
+
     public async Task<Budget> AddCategoryToBudget(string budget_id, List<Category> categoryList)
     {
         await _dbService.AddCategoryAsync(budget_id, categoryList);

--- a/ui/components/add_expense_modal.tsx
+++ b/ui/components/add_expense_modal.tsx
@@ -26,6 +26,9 @@ export interface AddExpenseModalProps {
   categories: { id: number; name: string }[];
   defaultCategoryId: number;
   defaultAmount: number;
+  defaultTitle?: string;
+  modalTitle?: string;
+  submitLabel?: string;
   isLoading?: boolean;
   onClose: () => void;
   onSubmit: (title: string, amount: number, categoryId: number) => void;
@@ -36,6 +39,9 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({
   categories,
   defaultCategoryId,
   defaultAmount,
+  defaultTitle,
+  modalTitle = "Add Expense",
+  submitLabel = "Add",
   onClose,
   onSubmit,
   isLoading,
@@ -55,7 +61,7 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({
   };
   return (
     <Modal
-      title="Add Expense"
+      title={modalTitle}
       open={isOpen}
       loading={isLoading}
       onCancel={onClose}
@@ -64,14 +70,14 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({
           Cancel
         </Button>,
         <Button key="submit" type="primary" onClick={handleOk}>
-          Add
+          {submitLabel}
         </Button>,
       ]}
     >
       <Form
         form={form}
         layout="vertical"
-        initialValues={{ categoryId: defaultCategoryId, amount: defaultAmount }}
+        initialValues={{ categoryId: defaultCategoryId, amount: defaultAmount, title: defaultTitle }}
       >
         <Form.Item
           label="Category"

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -25,7 +25,7 @@ import { getDataService } from "../services/data_service";
 import { ExpenseDetailsModal } from "./expense_details_modal";
 
 export interface EditExpenseModalProps {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number; addedBy: string } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
   categories: { id: number; name: string }[];
   budgetId: string;
   defaultCategoryId: number;
@@ -59,7 +59,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
           categoryId,
           amount,
           title,
-          addedBy: editingExpense.addedBy,
+          addedBy: "",
           timestamp: Date.now(),
         };
         onLoadingChange(true);

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -1,0 +1,76 @@
+/*
+ * BudgetBud - Budgeting and Expense Tracker with WebUI and API server
+ * Copyright (C) 2024  Sidhin S Thomas <sidhin.thomas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The source is available at: https://github.com/ParadoxZero/budgetbud
+ */
+
+import React from "react";
+import { DataModelFactory } from "../datamodel/datamodel";
+import { budgetSlice, store } from "../store";
+import { getDataService } from "../services/data_service";
+import { ExpenseDetailsModal } from "./expense_details_modal";
+
+export interface EditExpenseModalProps {
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  categories: { id: number; name: string }[];
+  budgetId: string;
+  defaultCategoryId: number;
+  onClose: () => void;
+  onLoadingChange: (loading: boolean) => void;
+}
+
+export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
+  editingExpense,
+  categories,
+  budgetId,
+  defaultCategoryId,
+  onClose,
+  onLoadingChange,
+}) => {
+  const dataService = getDataService();
+  return (
+    <ExpenseDetailsModal
+      isOpen={editingExpense !== null}
+      categories={categories}
+      defaultCategoryId={editingExpense?.categoryId ?? defaultCategoryId}
+      defaultAmount={editingExpense?.amount ?? 0}
+      defaultTitle={editingExpense?.title}
+      modalTitle="Edit Expense"
+      submitLabel="Save"
+      onClose={onClose}
+      onSubmit={(title, amount, categoryId) => {
+        if (!editingExpense) return;
+        const expense = DataModelFactory.createExpense(
+          editingExpense.id,
+          categoryId,
+          amount,
+          title,
+        );
+        onLoadingChange(true);
+        dataService
+          .updateExpense(budgetId, expense)
+          .then((budget) => {
+            store.dispatch(budgetSlice.actions.updateCurrent(budget));
+          })
+          .finally(() => {
+            onLoadingChange(false);
+          });
+        onClose();
+      }}
+    />
+  );
+};

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -19,7 +19,7 @@
  */
 
 import React from "react";
-import { DataModelFactory } from "../datamodel/datamodel";
+import { Expense } from "../datamodel/datamodel";
 import { budgetSlice, store } from "../store";
 import { getDataService } from "../services/data_service";
 import { ExpenseDetailsModal } from "./expense_details_modal";
@@ -54,15 +54,17 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
       onClose={onClose}
       onSubmit={(title, amount, categoryId) => {
         if (!editingExpense) return;
-        const expense = DataModelFactory.createExpense(
-          editingExpense.id,
+        const expense: Expense = {
+          id: editingExpense.id,
           categoryId,
           amount,
           title,
-        );
+          addedBy: "",
+          timestamp: Date.now(),
+        };
         onLoadingChange(true);
         dataService
-          .updateExpense(budgetId, expense)
+          .editExpense(budgetId, expense)
           .then((budget) => {
             store.dispatch(budgetSlice.actions.updateCurrent(budget));
           })

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -25,7 +25,7 @@ import { getDataService } from "../services/data_service";
 import { ExpenseDetailsModal } from "./expense_details_modal";
 
 export interface EditExpenseModalProps {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number; addedBy: string } | null;
   categories: { id: number; name: string }[];
   budgetId: string;
   defaultCategoryId: number;
@@ -59,7 +59,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
           categoryId,
           amount,
           title,
-          addedBy: "",
+          addedBy: editingExpense.addedBy,
           timestamp: Date.now(),
         };
         onLoadingChange(true);

--- a/ui/components/expense_details_modal.tsx
+++ b/ui/components/expense_details_modal.tsx
@@ -21,7 +21,7 @@
 import React from "react";
 import { Modal, Input, Select, Button, Form } from "antd";
 
-export interface AddExpenseModalProps {
+export interface ExpenseDetailsModalProps {
   isOpen: boolean;
   categories: { id: number; name: string }[];
   defaultCategoryId: number;
@@ -34,7 +34,7 @@ export interface AddExpenseModalProps {
   onSubmit: (title: string, amount: number, categoryId: number) => void;
 }
 
-export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({
+export const ExpenseDetailsModal: React.FC<ExpenseDetailsModalProps> = ({
   isOpen,
   categories,
   defaultCategoryId,

--- a/ui/pages/overview.tsx
+++ b/ui/pages/overview.tsx
@@ -67,7 +67,7 @@ import {
 
 import "../main.css";
 import { connect } from "react-redux";
-import { AddExpenseModal } from "../components/add_expense_modal";
+import { ExpenseDetailsModal } from "../components/expense_details_modal";
 import SingleCategory from "../components/single_category";
 import EditCategory, { EditCategoryState } from "../components/edit_category";
 import { ShareBudgetModal } from "../components/share_budget_modal";
@@ -411,7 +411,7 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
     const context = this.state.add_expense_mode_context;
     if (!context) return null;
     return (
-      <AddExpenseModal
+      <ExpenseDetailsModal
         isOpen={context.isModalOpen || false}
         categories={categories}
         defaultCategoryId={context.category_id}

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -49,57 +49,7 @@ import { DataService, getDataService } from "../services/data_service";
 import header from "../components/header";
 import { TicksToDate } from "../utils";
 import { ExpenseDetailsModal } from "../components/expense_details_modal";
-
-interface EditExpenseModalProps {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
-  categories: { id: number; name: string }[];
-  budgetId: string;
-  defaultCategoryId: number;
-  onClose: () => void;
-  onLoadingChange: (loading: boolean) => void;
-}
-
-const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
-  editingExpense,
-  categories,
-  budgetId,
-  defaultCategoryId,
-  onClose,
-  onLoadingChange,
-}) => {
-  const dataService = getDataService();
-  return (
-    <ExpenseDetailsModal
-      isOpen={editingExpense !== null}
-      categories={categories}
-      defaultCategoryId={editingExpense?.categoryId ?? defaultCategoryId}
-      defaultAmount={editingExpense?.amount ?? 0}
-      defaultTitle={editingExpense?.title}
-      modalTitle="Edit Expense"
-      submitLabel="Save"
-      onClose={onClose}
-      onSubmit={(title, amount, categoryId) => {
-        if (!editingExpense) return;
-        const expense = DataModelFactory.createExpense(
-          editingExpense.id,
-          categoryId,
-          amount,
-          title,
-        );
-        onLoadingChange(true);
-        dataService
-          .updateExpense(budgetId, expense)
-          .then((budget) => {
-            store.dispatch(budgetSlice.actions.updateCurrent(budget));
-          })
-          .finally(() => {
-            onLoadingChange(false);
-          });
-        onClose();
-      }}
-    />
-  );
-};
+import { EditExpenseModal } from "../components/edit_expense_modal";
 
 export interface ViewExpensePageProps {
   budget: Budget;

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -48,7 +48,58 @@ import { connect } from "react-redux";
 import { DataService, getDataService } from "../services/data_service";
 import header from "../components/header";
 import { TicksToDate } from "../utils";
-import { AddExpenseModal } from "../components/add_expense_modal";
+import { ExpenseDetailsModal } from "../components/expense_details_modal";
+
+interface EditExpenseModalProps {
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  categories: { id: number; name: string }[];
+  budgetId: string;
+  defaultCategoryId: number;
+  onClose: () => void;
+  onLoadingChange: (loading: boolean) => void;
+}
+
+const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
+  editingExpense,
+  categories,
+  budgetId,
+  defaultCategoryId,
+  onClose,
+  onLoadingChange,
+}) => {
+  const dataService = getDataService();
+  return (
+    <ExpenseDetailsModal
+      isOpen={editingExpense !== null}
+      categories={categories}
+      defaultCategoryId={editingExpense?.categoryId ?? defaultCategoryId}
+      defaultAmount={editingExpense?.amount ?? 0}
+      defaultTitle={editingExpense?.title}
+      modalTitle="Edit Expense"
+      submitLabel="Save"
+      onClose={onClose}
+      onSubmit={(title, amount, categoryId) => {
+        if (!editingExpense) return;
+        const expense = DataModelFactory.createExpense(
+          editingExpense.id,
+          categoryId,
+          amount,
+          title,
+        );
+        onLoadingChange(true);
+        dataService
+          .updateExpense(budgetId, expense)
+          .then((budget) => {
+            store.dispatch(budgetSlice.actions.updateCurrent(budget));
+          })
+          .finally(() => {
+            onLoadingChange(false);
+          });
+        onClose();
+      }}
+    />
+  );
+};
 
 export interface ViewExpensePageProps {
   budget: Budget;
@@ -110,7 +161,14 @@ class ViewExpensePage extends React.Component<
         <Divider />
         {this.render_body()}
         {this.render_add_expense_modal()}
-        {this.render_edit_expense_modal()}
+        <EditExpenseModal
+          editingExpense={this.state.editingExpense}
+          categories={this.props.budget.categoryList.map((c) => ({ id: c.id, name: c.name }))}
+          budgetId={this.props.budget.id}
+          defaultCategoryId={this.props.categoryId}
+          onClose={() => this.setState({ editingExpense: null })}
+          onLoadingChange={(loading) => this.setState({ isLoading: loading })}
+        />
       </Flex>
     );
   }
@@ -123,7 +181,7 @@ class ViewExpensePage extends React.Component<
     }));
 
     return (
-      <AddExpenseModal
+      <ExpenseDetailsModal
         isOpen={this.state.isAddExpenseModalOpen}
         categories={categories}
         defaultCategoryId={this.props.categoryId}
@@ -132,7 +190,6 @@ class ViewExpensePage extends React.Component<
           this.setState({ isAddExpenseModalOpen: false });
         }}
         onSubmit={(title, amount, categoryId) => {
-          console.log("Adding expense", title, amount, categoryId);
           const expense = DataModelFactory.createExpense(
             0,
             categoryId,
@@ -148,48 +205,6 @@ class ViewExpensePage extends React.Component<
               this.setState({ isLoading: false });
             });
           this.setState({ isAddExpenseModalOpen: false, isLoading: true });
-        }}
-      />
-    );
-  }
-
-  render_edit_expense_modal() {
-    const { editingExpense } = this.state;
-    const budget = this.props.budget;
-    const categories = budget.categoryList.map((category) => ({
-      id: category.id,
-      name: category.name,
-    }));
-
-    return (
-      <AddExpenseModal
-        isOpen={editingExpense !== null}
-        categories={categories}
-        defaultCategoryId={editingExpense?.categoryId ?? this.props.categoryId}
-        defaultAmount={editingExpense?.amount ?? 0}
-        defaultTitle={editingExpense?.title}
-        modalTitle="Edit Expense"
-        submitLabel="Save"
-        onClose={() => {
-          this.setState({ editingExpense: null });
-        }}
-        onSubmit={(title, amount, categoryId) => {
-          if (!editingExpense) return;
-          const expense = DataModelFactory.createExpense(
-            editingExpense.id,
-            categoryId,
-            amount,
-            title,
-          );
-          this._data_service
-            .updateExpense(this.props.budget.id, expense)
-            .then((budget) => {
-              store.dispatch(budgetSlice.actions.updateCurrent(budget));
-            })
-            .finally(() => {
-              this.setState({ isLoading: false });
-            });
-          this.setState({ editingExpense: null, isLoading: true });
         }}
       />
     );

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -317,7 +317,7 @@ class ViewExpensePage extends React.Component<
     return (
       <>
         <Timeline
-          mode="alternate"
+          mode="left"
           items={item_list}
           style={{ minWidth: 300 }}
           reverse

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -59,7 +59,7 @@ export interface ViewExpensePageProps {
 interface ViewExpensePageState {
   isAddExpenseModalOpen: boolean;
   isLoading: boolean;
-  editingExpense: { id: number; title: string; amount: number; categoryId: number; addedBy: string } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
 }
 
 class ViewExpensePage extends React.Component<
@@ -223,7 +223,6 @@ class ViewExpensePage extends React.Component<
             title: expense.title,
             amount: expense.amount,
             categoryId: expense.categoryId,
-            addedBy: expense.addedBy,
           },
         });
       };

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -58,6 +58,7 @@ export interface ViewExpensePageProps {
 interface ViewExpensePageState {
   isAddExpenseModalOpen: boolean;
   isLoading: boolean;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
 }
 
 class ViewExpensePage extends React.Component<
@@ -72,6 +73,7 @@ class ViewExpensePage extends React.Component<
     this.state = {
       isAddExpenseModalOpen: false,
       isLoading: false,
+      editingExpense: null,
     };
   }
 
@@ -108,6 +110,7 @@ class ViewExpensePage extends React.Component<
         <Divider />
         {this.render_body()}
         {this.render_add_expense_modal()}
+        {this.render_edit_expense_modal()}
       </Flex>
     );
   }
@@ -145,6 +148,48 @@ class ViewExpensePage extends React.Component<
               this.setState({ isLoading: false });
             });
           this.setState({ isAddExpenseModalOpen: false, isLoading: true });
+        }}
+      />
+    );
+  }
+
+  render_edit_expense_modal() {
+    const { editingExpense } = this.state;
+    const budget = this.props.budget;
+    const categories = budget.categoryList.map((category) => ({
+      id: category.id,
+      name: category.name,
+    }));
+
+    return (
+      <AddExpenseModal
+        isOpen={editingExpense !== null}
+        categories={categories}
+        defaultCategoryId={editingExpense?.categoryId ?? this.props.categoryId}
+        defaultAmount={editingExpense?.amount ?? 0}
+        defaultTitle={editingExpense?.title}
+        modalTitle="Edit Expense"
+        submitLabel="Save"
+        onClose={() => {
+          this.setState({ editingExpense: null });
+        }}
+        onSubmit={(title, amount, categoryId) => {
+          if (!editingExpense) return;
+          const expense = DataModelFactory.createExpense(
+            editingExpense.id,
+            categoryId,
+            amount,
+            title,
+          );
+          this._data_service
+            .updateExpense(this.props.budget.id, expense)
+            .then((budget) => {
+              store.dispatch(budgetSlice.actions.updateCurrent(budget));
+            })
+            .finally(() => {
+              this.setState({ isLoading: false });
+            });
+          this.setState({ editingExpense: null, isLoading: true });
         }}
       />
     );
@@ -206,6 +251,16 @@ class ViewExpensePage extends React.Component<
             store.dispatch(budgetSlice.actions.updateCurrent(budget));
           });
       };
+      const on_edit_click = () => {
+        this.setState({
+          editingExpense: {
+            id: expense.id,
+            title: expense.title,
+            amount: expense.amount,
+            categoryId: expense.categoryId,
+          },
+        });
+      };
       const ui = (
         <div>
           <Flex
@@ -216,22 +271,31 @@ class ViewExpensePage extends React.Component<
           >
             <Flex vertical gap={15} justify="space-evenly" align="stretch">
               <Statistic title={date_string} value={expense.amount} />
-              <Popconfirm
-                title="Are you sure?"
-                okText="Yes"
-                showArrow
-                onConfirm={on_delete_click}
-              >
+              <Space>
                 <Button
                   size="middle"
-                  icon={<DeleteFilled />}
+                  icon={<EditFilled />}
                   shape="default"
-                  danger
+                  onClick={on_edit_click}
                 >
-                  {" "}
-                  Delete{" "}
+                  Edit
                 </Button>
-              </Popconfirm>
+                <Popconfirm
+                  title="Are you sure?"
+                  okText="Yes"
+                  showArrow
+                  onConfirm={on_delete_click}
+                >
+                  <Button
+                    size="middle"
+                    icon={<DeleteFilled />}
+                    shape="default"
+                    danger
+                  >
+                    Delete
+                  </Button>
+                </Popconfirm>
+              </Space>
             </Flex>
           </Flex>
         </div>

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -59,7 +59,7 @@ export interface ViewExpensePageProps {
 interface ViewExpensePageState {
   isAddExpenseModalOpen: boolean;
   isLoading: boolean;
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number; addedBy: string } | null;
 }
 
 class ViewExpensePage extends React.Component<
@@ -223,6 +223,7 @@ class ViewExpensePage extends React.Component<
             title: expense.title,
             amount: expense.amount,
             categoryId: expense.categoryId,
+            addedBy: expense.addedBy,
           },
         });
       };

--- a/ui/services/data_service.ts
+++ b/ui/services/data_service.ts
@@ -46,6 +46,7 @@ export interface DataService {
   ): Promise<Budget>;
   deleteCategory(budget_id: string, categoryId: number): Promise<Budget>;
   updateExpense(budget_id: string, expense: Expense): Promise<Budget>;
+  editExpense(budget_id: string, expense: Expense): Promise<Budget>;
   deleteExpense(
     budget_id: string,
     category_id: number,

--- a/ui/services/local_data_service.ts
+++ b/ui/services/local_data_service.ts
@@ -265,6 +265,35 @@ export class LocalDataService implements DataService {
     });
   }
 
+  editExpense(_budget_id: string, expense: Expense): Promise<Budget> {
+    return new Promise((resolve, reject) => {
+      const user_data = localStorage.getItem("userData") ?? "[]";
+      if (user_data) {
+        let budget_list: Budget[] = JSON.parse(user_data);
+        const index = this.find_budget_by_id(_budget_id, budget_list);
+        if (index === -1) {
+          reject();
+          return;
+        }
+        budget_list[index].categoryList = budget_list[index].categoryList.map(
+          (c: Category) => {
+            if (c.id === expense.categoryId) {
+              c.expenseList = c.expenseList.map((e: Expense) =>
+                e.id === expense.id ? expense : e,
+              );
+            }
+            return c;
+          },
+        );
+        budget_list[index].last_updated = Date.now();
+        localStorage.setItem("userData", JSON.stringify(budget_list));
+        resolve(budget_list[index]);
+      } else {
+        reject();
+      }
+    });
+  }
+
   deleteExpense(
     _budget_id: string,
     category_id: number,

--- a/ui/services/remote_data_service.ts
+++ b/ui/services/remote_data_service.ts
@@ -122,6 +122,17 @@ export class RemoteDataService implements DataService {
     }).then((response) => response.json() as Promise<Budget>);
   }
 
+  editExpense(_budget_id: string, expense: Expense): Promise<Budget> {
+    const endpoint: string = `${this.BASE_URL}/api/Budget/${_budget_id}/expense`;
+    return fetchData(endpoint, {
+      method: "PUT",
+      body: JSON.stringify(expense),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((response) => response.json() as Promise<Budget>);
+  }
+
   deleteExpense(
     _budget_id: string,
     category_id: number,


### PR DESCRIPTION
## Summary
This PR adds the ability to edit existing expenses in the expense view page. Users can now click an "Edit" button on any expense to modify its title, amount, and category through a modal dialog.

## Key Changes
- **ViewExpensePage state**: Added `editingExpense` state to track which expense is being edited
- **Edit modal**: Implemented `render_edit_expense_modal()` method that reuses the `AddExpenseModal` component for editing
- **Edit button**: Added an "Edit" button next to the delete button in the expense display, with an `on_edit_click` handler that populates the editing state
- **AddExpenseModal enhancements**: Extended the modal component to support editing by adding:
  - `defaultTitle` prop to pre-fill the title field
  - `modalTitle` prop to customize the modal header (defaults to "Add Expense")
  - `submitLabel` prop to customize the submit button text (defaults to "Add")
- **UI layout**: Wrapped the edit and delete buttons in a `Space` component for better spacing

## Implementation Details
- The edit modal reuses the existing `AddExpenseModal` component with customized props for the editing workflow
- When submitting an edit, the component calls `updateExpense()` on the data service and dispatches the updated budget to the store
- The loading state is properly managed during the update operation
- The modal closes automatically after a successful edit by clearing the `editingExpense` state

https://claude.ai/code/session_01Mdn9wjb1aGyjQynAZveit8