### PR TITLE
Add view all expenses page with edit/delete actions

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -30,6 +30,7 @@ import Overview from "./pages/overview";
 import EditCategoriesPage from "./pages/edit_categories_page";
 import { Budget } from "./datamodel/datamodel";
 import CategoryDetails from "./pages/view_expense_page";
+import AllExpensesPage from "./pages/all_expenses_page";
 import { View } from "./store";
 import { GithubOutlined } from "@ant-design/icons";
 import AppFooter from "./components/app_footer";
@@ -149,6 +150,8 @@ class App extends React.Component<AppProps> {
         return <EditCategoriesPage budget={this.props.current_budget!} />;
       case View.CategoryDetails:
         return <CategoryDetails budget={this.props.current_budget!} />;
+      case View.AllExpenses:
+        return <AllExpensesPage budget={this.props.current_budget!} />;
       default:
         return <>Not Found</>;
     }

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -1,0 +1,108 @@
+/*
+ * BudgetBud - Budgeting and Expense Tracker with WebUI and API server
+ * Copyright (C) 2025  Sidhin S Thomas <sidhin.thomas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The source is available at: https://github.com/ParadoxZero/budgetbud
+ */
+
+import React, { useEffect } from "react";
+import { Modal, Input, Select, Button, Form } from "antd";
+import { Expense } from "../datamodel/datamodel";
+
+export interface EditExpenseModalProps {
+  isOpen: boolean;
+  categories: { id: number; name: string }[];
+  expense: Expense;
+  isLoading?: boolean;
+  onClose: () => void;
+  onSubmit: (title: string, amount: number, categoryId: number) => void;
+}
+
+export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
+  isOpen,
+  categories,
+  expense,
+  onClose,
+  onSubmit,
+  isLoading,
+}) => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (isOpen) {
+      form.setFieldsValue({
+        categoryId: expense.categoryId,
+        amount: expense.amount,
+        title: expense.title,
+      });
+    }
+  }, [isOpen, expense, form]);
+
+  const handleOk = () => {
+    form
+      .validateFields()
+      .then((values) => {
+        onSubmit(values.title, parseFloat(values.amount), values.categoryId);
+        form.resetFields();
+      })
+      .catch((info) => {
+        console.error("Validation Failed:", info);
+      });
+  };
+
+  return (
+    <Modal
+      title="Edit Expense"
+      open={isOpen}
+      loading={isLoading}
+      onCancel={onClose}
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Cancel
+        </Button>,
+        <Button key="submit" type="primary" onClick={handleOk}>
+          Save
+        </Button>,
+      ]}
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label="Category"
+          name="categoryId"
+          rules={[{ required: true, message: "Please select a category" }]}
+        >
+          <Select placeholder="Select a category">
+            {categories.map((category) => (
+              <Select.Option key={category.id} value={category.id}>
+                {category.name}
+              </Select.Option>
+            ))}
+          </Select>
+        </Form.Item>
+        <Form.Item label="Title" name="title">
+          <Input placeholder="Expense Title" />
+        </Form.Item>
+        <Form.Item
+          label="Amount"
+          name="amount"
+          rules={[{ required: true, message: "Please enter an amount" }]}
+        >
+          <Input type="number" placeholder="Expense Amount" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -25,7 +25,7 @@ import { getDataService } from "../services/data_service";
 import { ExpenseDetailsModal } from "./expense_details_modal";
 
 export interface EditExpenseModalProps {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
   categories: { id: number; name: string }[];
   budgetId: string;
   defaultCategoryId: number;
@@ -60,7 +60,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
           amount,
           title,
           addedBy: "",
-          timestamp: Date.now(),
+          timestamp: editingExpense.timestamp,
         };
         onLoadingChange(true);
         dataService

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -25,7 +25,7 @@ import { getDataService } from "../services/data_service";
 import { ExpenseDetailsModal } from "./expense_details_modal";
 
 export interface EditExpenseModalProps {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
   categories: { id: number; name: string }[];
   budgetId: string;
   defaultCategoryId: number;
@@ -60,7 +60,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
           amount,
           title,
           addedBy: "",
-          timestamp: editingExpense.timestamp,
+          timestamp: 0,
         };
         onLoadingChange(true);
         dataService

--- a/ui/components/edit_expense_modal.tsx
+++ b/ui/components/edit_expense_modal.tsx
@@ -54,14 +54,13 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
       onClose={onClose}
       onSubmit={(title, amount, categoryId) => {
         if (!editingExpense) return;
-        const expense: Expense = {
+        const expense = {
           id: editingExpense.id,
           categoryId,
           amount,
           title,
           addedBy: "",
-          timestamp: 0,
-        };
+        } as Expense;
         onLoadingChange(true);
         dataService
           .editExpense(budgetId, expense)

--- a/ui/components/expense_details_modal.tsx
+++ b/ui/components/expense_details_modal.tsx
@@ -48,6 +48,16 @@ export const ExpenseDetailsModal: React.FC<ExpenseDetailsModalProps> = ({
 }) => {
   const [form] = Form.useForm();
 
+  React.useEffect(() => {
+    if (isOpen) {
+      form.setFieldsValue({
+        categoryId: defaultCategoryId,
+        amount: defaultAmount,
+        title: defaultTitle ?? "",
+      });
+    }
+  }, [isOpen, defaultCategoryId, defaultAmount, defaultTitle, form]);
+
   const handleOk = () => {
     form
       .validateFields()

--- a/ui/pages/all_expenses_page.tsx
+++ b/ui/pages/all_expenses_page.tsx
@@ -32,7 +32,7 @@ export interface AllExpensesPageProps {
 }
 
 interface AllExpensesPageState {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
   isLoading: boolean;
 }
 
@@ -159,7 +159,7 @@ class AllExpensesPage extends React.Component<
                 icon={<EditFilled />}
                 size="small"
                 onClick={() => expense && this.setState({
-                  editingExpense: { id: expense.id, title: expense.title, amount: expense.amount, categoryId: expense.categoryId, timestamp: expense.timestamp },
+                  editingExpense: { id: expense.id, title: expense.title, amount: expense.amount, categoryId: expense.categoryId },
                 })}
               >
                 Edit

--- a/ui/pages/all_expenses_page.tsx
+++ b/ui/pages/all_expenses_page.tsx
@@ -19,7 +19,7 @@
  */
 
 import React from "react";
-import { Budget, Expense } from "../datamodel/datamodel";
+import { Budget } from "../datamodel/datamodel";
 import { budgetSlice, headerSlice, navigate, store, View } from "../store";
 import { Button, Flex, Popconfirm, Table, Tag, Typography } from "antd";
 import { DeleteFilled, EditFilled, LeftOutlined } from "@ant-design/icons";
@@ -32,7 +32,7 @@ export interface AllExpensesPageProps {
 }
 
 interface AllExpensesPageState {
-  editingExpense: Expense | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
   isLoading: boolean;
 }
 
@@ -99,25 +99,6 @@ class AllExpensesPage extends React.Component<
       });
   }
 
-  handleEditSubmit(title: string, amount: number, categoryId: number) {
-    if (!this.state.editingExpense) return;
-    const updatedExpense: Expense = {
-      ...this.state.editingExpense,
-      title,
-      amount,
-      categoryId,
-    };
-    this.setState({ isLoading: true, editingExpense: null });
-    this._data_service
-      .updateExpense(this.props.budget.id, updatedExpense)
-      .then((budget) => {
-        store.dispatch(budgetSlice.actions.updateCurrent(budget));
-      })
-      .finally(() => {
-        this.setState({ isLoading: false });
-      });
-  }
-
   render() {
     const categories = this.props.budget.categoryList.map((c) => ({
       id: c.id,
@@ -176,7 +157,9 @@ class AllExpensesPage extends React.Component<
               <Button
                 icon={<EditFilled />}
                 size="small"
-                onClick={() => expense && this.setState({ editingExpense: expense })}
+                onClick={() => expense && this.setState({
+                  editingExpense: { id: expense.id, title: expense.title, amount: expense.amount, categoryId: expense.categoryId },
+                })}
               >
                 Edit
               </Button>
@@ -220,18 +203,14 @@ class AllExpensesPage extends React.Component<
           scroll={{ x: "max-content" }}
           locale={{ emptyText: "No expenses recorded yet." }}
         />
-        {this.state.editingExpense && (
-          <EditExpenseModal
-            isOpen={true}
-            categories={categories}
-            expense={this.state.editingExpense}
-            isLoading={this.state.isLoading}
-            onClose={() => this.setState({ editingExpense: null })}
-            onSubmit={(title, amount, categoryId) =>
-              this.handleEditSubmit(title, amount, categoryId)
-            }
-          />
-        )}
+        <EditExpenseModal
+          editingExpense={this.state.editingExpense}
+          categories={categories}
+          budgetId={this.props.budget.id}
+          defaultCategoryId={this.props.budget.categoryList[0]?.id ?? 0}
+          onClose={() => this.setState({ editingExpense: null })}
+          onLoadingChange={(loading) => this.setState({ isLoading: loading })}
+        />
       </Flex>
     );
   }

--- a/ui/pages/all_expenses_page.tsx
+++ b/ui/pages/all_expenses_page.tsx
@@ -32,7 +32,7 @@ export interface AllExpensesPageProps {
 }
 
 interface AllExpensesPageState {
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
   isLoading: boolean;
 }
 
@@ -145,6 +145,7 @@ class AllExpensesPage extends React.Component<
       {
         title: "Actions",
         key: "actions",
+        align: "center" as const,
         render: (_: unknown, record: ExpenseRow) => {
           const category = this.props.budget.categoryList.find(
             (c) => c.id === record.categoryId,
@@ -158,7 +159,7 @@ class AllExpensesPage extends React.Component<
                 icon={<EditFilled />}
                 size="small"
                 onClick={() => expense && this.setState({
-                  editingExpense: { id: expense.id, title: expense.title, amount: expense.amount, categoryId: expense.categoryId },
+                  editingExpense: { id: expense.id, title: expense.title, amount: expense.amount, categoryId: expense.categoryId, timestamp: expense.timestamp },
                 })}
               >
                 Edit

--- a/ui/pages/all_expenses_page.tsx
+++ b/ui/pages/all_expenses_page.tsx
@@ -1,0 +1,240 @@
+/*
+ * BudgetBud - Budgeting and Expense Tracker with WebUI and API server
+ * Copyright (C) 2025  Sidhin S Thomas <sidhin.thomas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The source is available at: https://github.com/ParadoxZero/budgetbud
+ */
+
+import React from "react";
+import { Budget, Expense } from "../datamodel/datamodel";
+import { budgetSlice, headerSlice, navigate, store, View } from "../store";
+import { Button, Flex, Popconfirm, Table, Tag, Typography } from "antd";
+import { DeleteFilled, EditFilled, LeftOutlined } from "@ant-design/icons";
+import { DataService, getDataService } from "../services/data_service";
+import { TicksToDate } from "../utils";
+import { EditExpenseModal } from "../components/edit_expense_modal";
+
+export interface AllExpensesPageProps {
+  budget: Budget;
+}
+
+interface AllExpensesPageState {
+  editingExpense: Expense | null;
+  isLoading: boolean;
+}
+
+interface ExpenseRow {
+  key: string;
+  expenseId: number;
+  categoryId: number;
+  title: string;
+  addedBy: string;
+  amount: number;
+  categoryName: string;
+  timestamp: number;
+}
+
+class AllExpensesPage extends React.Component<
+  AllExpensesPageProps,
+  AllExpensesPageState
+> {
+  _data_service: DataService;
+
+  constructor(props: AllExpensesPageProps) {
+    super(props);
+    this._data_service = getDataService();
+    this.state = {
+      editingExpense: null,
+      isLoading: false,
+    };
+  }
+
+  componentDidMount(): void {
+    store.dispatch(
+      headerSlice.actions.setTitle({ title: "All Expenses", show_title: true }),
+    );
+  }
+
+  getExpenseRows(): ExpenseRow[] {
+    const rows: ExpenseRow[] = [];
+    for (const category of this.props.budget.categoryList) {
+      for (const expense of category.expenseList) {
+        rows.push({
+          key: `${category.id}-${expense.id}`,
+          expenseId: expense.id,
+          categoryId: category.id,
+          title: expense.title || "",
+          addedBy: expense.addedBy || "Unknown",
+          amount: expense.amount,
+          categoryName: category.name,
+          timestamp: expense.timestamp,
+        });
+      }
+    }
+    return rows.sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  handleDelete(categoryId: number, expenseId: number) {
+    this.setState({ isLoading: true });
+    this._data_service
+      .deleteExpense(this.props.budget.id, categoryId, expenseId)
+      .then((budget) => {
+        store.dispatch(budgetSlice.actions.updateCurrent(budget));
+      })
+      .finally(() => {
+        this.setState({ isLoading: false });
+      });
+  }
+
+  handleEditSubmit(title: string, amount: number, categoryId: number) {
+    if (!this.state.editingExpense) return;
+    const updatedExpense: Expense = {
+      ...this.state.editingExpense,
+      title,
+      amount,
+      categoryId,
+    };
+    this.setState({ isLoading: true, editingExpense: null });
+    this._data_service
+      .updateExpense(this.props.budget.id, updatedExpense)
+      .then((budget) => {
+        store.dispatch(budgetSlice.actions.updateCurrent(budget));
+      })
+      .finally(() => {
+        this.setState({ isLoading: false });
+      });
+  }
+
+  render() {
+    const categories = this.props.budget.categoryList.map((c) => ({
+      id: c.id,
+      name: c.name,
+    }));
+
+    const columns = [
+      {
+        title: "Date",
+        dataIndex: "timestamp",
+        key: "timestamp",
+        render: (timestamp: number) =>
+          TicksToDate(timestamp).toLocaleDateString(),
+      },
+      {
+        title: "Title",
+        dataIndex: "title",
+        key: "title",
+        render: (title: string) =>
+          title ? (
+            title
+          ) : (
+            <Typography.Text type="secondary">—</Typography.Text>
+          ),
+      },
+      {
+        title: "Added By",
+        dataIndex: "addedBy",
+        key: "addedBy",
+      },
+      {
+        title: "Amount",
+        dataIndex: "amount",
+        key: "amount",
+        render: (amount: number) => amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+        align: "right" as const,
+      },
+      {
+        title: "Category",
+        dataIndex: "categoryName",
+        key: "categoryName",
+        render: (name: string) => <Tag>{name}</Tag>,
+      },
+      {
+        title: "Actions",
+        key: "actions",
+        render: (_: unknown, record: ExpenseRow) => {
+          const category = this.props.budget.categoryList.find(
+            (c) => c.id === record.categoryId,
+          );
+          const expense = category?.expenseList.find(
+            (e) => e.id === record.expenseId,
+          );
+          return (
+            <Flex gap={8}>
+              <Button
+                icon={<EditFilled />}
+                size="small"
+                onClick={() => expense && this.setState({ editingExpense: expense })}
+              >
+                Edit
+              </Button>
+              <Popconfirm
+                title="Delete this expense?"
+                okText="Yes"
+                cancelText="No"
+                onConfirm={() =>
+                  this.handleDelete(record.categoryId, record.expenseId)
+                }
+              >
+                <Button icon={<DeleteFilled />} size="small" danger>
+                  Delete
+                </Button>
+              </Popconfirm>
+            </Flex>
+          );
+        },
+      },
+    ];
+
+    return (
+      <Flex vertical style={{ padding: 16 }}>
+        <Flex gap={10} style={{ marginBottom: 16 }}>
+          <Button
+            type="primary"
+            icon={<LeftOutlined />}
+            onClick={() => store.dispatch(navigate(View.Overview))}
+          >
+            Back
+          </Button>
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            All Expenses
+          </Typography.Title>
+        </Flex>
+        <Table
+          dataSource={this.getExpenseRows()}
+          columns={columns}
+          loading={this.state.isLoading}
+          pagination={{ pageSize: 20, showSizeChanger: false }}
+          scroll={{ x: "max-content" }}
+          locale={{ emptyText: "No expenses recorded yet." }}
+        />
+        {this.state.editingExpense && (
+          <EditExpenseModal
+            isOpen={true}
+            categories={categories}
+            expense={this.state.editingExpense}
+            isLoading={this.state.isLoading}
+            onClose={() => this.setState({ editingExpense: null })}
+            onSubmit={(title, amount, categoryId) =>
+              this.handleEditSubmit(title, amount, categoryId)
+            }
+          />
+        )}
+      </Flex>
+    );
+  }
+}
+
+export default AllExpensesPage;

--- a/ui/pages/overview.tsx
+++ b/ui/pages/overview.tsx
@@ -40,6 +40,7 @@ import {
   LinkOutlined,
   LoadingOutlined,
   PlusOutlined,
+  UnorderedListOutlined,
   WalletOutlined,
 } from "@ant-design/icons";
 import {
@@ -190,6 +191,14 @@ class OverviewPage extends React.Component<OverviewProps, IState> {
         onClick: () => {
           store.dispatch(navigate(View.CategoryEdit));
         }
+      },
+      {
+        label: "View All Expenses",
+        key: "6",
+        icon: <UnorderedListOutlined />,
+        onClick: () => {
+          store.dispatch(navigate(View.AllExpenses));
+        },
       },
       {
         label: "History",

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -59,7 +59,7 @@ export interface ViewExpensePageProps {
 interface ViewExpensePageState {
   isAddExpenseModalOpen: boolean;
   isLoading: boolean;
-  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
 }
 
 class ViewExpensePage extends React.Component<
@@ -223,7 +223,6 @@ class ViewExpensePage extends React.Component<
             title: expense.title,
             amount: expense.amount,
             categoryId: expense.categoryId,
-            timestamp: expense.timestamp,
           },
         });
       };

--- a/ui/pages/view_expense_page.tsx
+++ b/ui/pages/view_expense_page.tsx
@@ -59,7 +59,7 @@ export interface ViewExpensePageProps {
 interface ViewExpensePageState {
   isAddExpenseModalOpen: boolean;
   isLoading: boolean;
-  editingExpense: { id: number; title: string; amount: number; categoryId: number } | null;
+  editingExpense: { id: number; title: string; amount: number; categoryId: number; timestamp: number } | null;
 }
 
 class ViewExpensePage extends React.Component<
@@ -223,6 +223,7 @@ class ViewExpensePage extends React.Component<
             title: expense.title,
             amount: expense.amount,
             categoryId: expense.categoryId,
+            timestamp: expense.timestamp,
           },
         });
       };

--- a/ui/store.ts
+++ b/ui/store.ts
@@ -27,6 +27,7 @@ export enum View {
   CategoryDetails,
   CategoryEdit,
   ExpenseDetails,
+  AllExpenses,
 }
 
 export const navigationSlice = createSlice({


### PR DESCRIPTION
- New AllExpenses view in View enum (store.ts)
- New all_expenses_page.tsx: table listing all expenses across categories,
  sorted newest-to-oldest, with columns: date, title, added by, amount,
  category tag, and edit/delete action buttons
- New edit_expense_modal.tsx: pre-filled modal for editing an existing expense
- App.tsx: wire AllExpenses view case
- overview.tsx: add "View All Expenses" menu item in the actions dropdown

https://claude.ai/code/session_01Eacop9fwJkMGRdHUtuGWBD